### PR TITLE
Double-quote scriptExecutablePath for Unix

### DIFF
--- a/src/intTest/java/org/siouan/frontendgradleplugin/infrastructure/gradle/TaskTypesWithDownloadedDistributionsFuncTest.java
+++ b/src/intTest/java/org/siouan/frontendgradleplugin/infrastructure/gradle/TaskTypesWithDownloadedDistributionsFuncTest.java
@@ -17,6 +17,7 @@ import static org.siouan.frontendgradleplugin.test.util.TaskTypes.createJavascri
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 import org.gradle.api.logging.LogLevel;
@@ -45,8 +46,9 @@ class TaskTypesWithDownloadedDistributionsFuncTest {
     private Path projectDirectoryPath;
 
     @BeforeEach
-    void setUp() {
-        projectDirectoryPath = temporaryDirectoryPath;
+    void setUp() throws IOException {
+        Path directoryPathWithSpace = Files.createDirectory(Paths.get(temporaryDirectoryPath.toString(), "some space"));
+        projectDirectoryPath = directoryPathWithSpace;
     }
 
     @Test

--- a/src/main/java/org/siouan/frontendgradleplugin/domain/usecase/ResolveExecutionSettings.java
+++ b/src/main/java/org/siouan/frontendgradleplugin/domain/usecase/ResolveExecutionSettings.java
@@ -117,13 +117,12 @@ public class ResolveExecutionSettings {
                 // variable.
                 args.add(scriptExecutablePath.toString() + ' ' + script.trim());
             } else {
-                // Enclose the executable path between double-quotes in case of the path contains whitespaces.
-                args.add('"' + scriptExecutablePath.toString() + "\" " + script.trim());
+                args.add(enclosePathInDoubleQuotesToEscapceWhitespace(scriptExecutablePath) + " " + script.trim());
             }
         } else {
             executable = UNIX_EXECUTABLE_PATH;
             args.add(UNIX_EXECUTABLE_AUTOEXIT_FLAG);
-            args.add(scriptExecutablePath.toString() + UNIX_SCRIPT_ARG_SEPARATOR_CHAR + String.join(
+            args.add(enclosePathInDoubleQuotesToEscapceWhitespace(scriptExecutablePath) + UNIX_SCRIPT_ARG_SEPARATOR_CHAR + String.join(
                 Character.toString(UNIX_SCRIPT_ARG_SEPARATOR_CHAR),
                 new StringSplitter(UNIX_SCRIPT_ARG_SEPARATOR_CHAR, UNIX_SCRIPT_ARG_ESCAPE_CHAR).execute(
                     script.trim())));
@@ -138,5 +137,9 @@ public class ResolveExecutionSettings {
         }
 
         return new ExecutionSettings(packageJsonDirectoryPath, executablePaths, executable, args);
+    }
+
+    private static String enclosePathInDoubleQuotesToEscapceWhitespace(Path path) {
+        return '"' + path.toString() + '"';
     }
 }

--- a/src/test/java/org/siouan/frontendgradleplugin/domain/usecase/ResolveExecutionSettingsTest.java
+++ b/src/test/java/org/siouan/frontendgradleplugin/domain/usecase/ResolveExecutionSettingsTest.java
@@ -259,7 +259,7 @@ class ResolveExecutionSettingsTest {
         assertThat(executionSettings.getAdditionalExecutablePaths()).isEmpty();
         assertThat(executionSettings.getExecutablePath()).isEqualTo(ResolveExecutionSettings.UNIX_EXECUTABLE_PATH);
         assertThat(executionSettings.getArguments()).containsExactly(
-            ResolveExecutionSettings.UNIX_EXECUTABLE_AUTOEXIT_FLAG, nodeExecutablePath + " run script");
+            ResolveExecutionSettings.UNIX_EXECUTABLE_AUTOEXIT_FLAG, "\"" + nodeExecutablePath + "\" run script");
         verifyNoMoreInteractions(getNodeExecutablePath, getNpmExecutablePath, getNpxExecutablePath,
             getYarnExecutablePath);
     }
@@ -280,7 +280,7 @@ class ResolveExecutionSettingsTest {
         assertThat(executionSettings.getAdditionalExecutablePaths()).containsExactly(nodeExecutablePath.getParent());
         assertThat(executionSettings.getExecutablePath()).isEqualTo(ResolveExecutionSettings.UNIX_EXECUTABLE_PATH);
         assertThat(executionSettings.getArguments()).containsExactly(
-            ResolveExecutionSettings.UNIX_EXECUTABLE_AUTOEXIT_FLAG, npmExecutablePath + " run script");
+            ResolveExecutionSettings.UNIX_EXECUTABLE_AUTOEXIT_FLAG, "\"" + npmExecutablePath + "\" run script");
         verifyNoMoreInteractions(getNodeExecutablePath, getNpmExecutablePath, getNpxExecutablePath,
             getYarnExecutablePath);
     }
@@ -301,7 +301,7 @@ class ResolveExecutionSettingsTest {
         assertThat(executionSettings.getAdditionalExecutablePaths()).containsExactly(nodeExecutablePath.getParent());
         assertThat(executionSettings.getExecutablePath()).isEqualTo(ResolveExecutionSettings.UNIX_EXECUTABLE_PATH);
         assertThat(executionSettings.getArguments()).containsExactly(
-            ResolveExecutionSettings.UNIX_EXECUTABLE_AUTOEXIT_FLAG, npxExecutablePath + " run script");
+            ResolveExecutionSettings.UNIX_EXECUTABLE_AUTOEXIT_FLAG, "\"" + npxExecutablePath + "\" run script");
         verifyNoMoreInteractions(getNodeExecutablePath, getNpmExecutablePath, getNpxExecutablePath,
             getYarnExecutablePath);
     }
@@ -322,7 +322,7 @@ class ResolveExecutionSettingsTest {
         assertThat(executionSettings.getAdditionalExecutablePaths()).containsExactly(nodeExecutablePath.getParent());
         assertThat(executionSettings.getExecutablePath()).isEqualTo(ResolveExecutionSettings.UNIX_EXECUTABLE_PATH);
         assertThat(executionSettings.getArguments()).containsExactly(
-            ResolveExecutionSettings.UNIX_EXECUTABLE_AUTOEXIT_FLAG, yarnExecutablePath + " run script");
+            ResolveExecutionSettings.UNIX_EXECUTABLE_AUTOEXIT_FLAG, "\"" + yarnExecutablePath + "\" run script");
         verifyNoMoreInteractions(getNodeExecutablePath, getNpmExecutablePath, getNpxExecutablePath,
             getYarnExecutablePath);
     }


### PR DESCRIPTION
to ensure spaces in path are escaped.

fixes #153